### PR TITLE
removed lxml dependency

### DIFF
--- a/pyraml/fields.py
+++ b/pyraml/fields.py
@@ -5,8 +5,8 @@ import importhelpers
 from abc import ABCMeta
 from collections import OrderedDict
 
-from lxml.etree import fromstring as parse_xml_string
-from lxml.etree import _Element as XMLElement
+from xml.etree.ElementTree import fromstring as parse_xml_string
+from xml.etree.ElementTree import _Element as XMLElement
 
 
 class BaseField(object):
@@ -553,7 +553,7 @@ class JSONData(EncodedDataBase):
 
 
 class XMLData(EncodedDataBase):
-    """ Represents a XML encoded data. Uses lxml parsing library. """
+    """ Represents a XML encoded data. Uses built-in xml parsing library. """
     result_type = XMLElement
 
     def load_data(self, value):

--- a/pyraml/fields.py
+++ b/pyraml/fields.py
@@ -5,9 +5,12 @@ import importhelpers
 from abc import ABCMeta
 from collections import OrderedDict
 
-from xml.etree.ElementTree import fromstring as parse_xml_string
-from xml.etree.ElementTree import _Element as XMLElement
-
+try:
+    from lxml.etree import fromstring as parse_xml_string
+    from lxml.etree import _Element as XMLElement
+except ImportError:
+    from xml.etree.ElementTree import fromstring as parse_xml_string
+    from xml.etree.ElementTree import _Element as XMLElement
 
 class BaseField(object):
     __metaclass__ = ABCMeta

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,6 @@ setup(
     description='Python parser for RAML.',
     long_description=open('README.md').read(),
     install_requires=[
-        'lxml==3.4.2',
         'setuptools',
         'PyYAML>=3.10',
         'importhelpers>=0.2'

--- a/tests/test_parser_functional.py
+++ b/tests/test_parser_functional.py
@@ -2,8 +2,11 @@ from .base import SampleParseTestCase
 from pyraml import entities
 
 from mock import patch
-from xml.etree.ElementTree import _Element as XMLElement
 
+try:
+    from lxml.etree import _Element as XMLElement
+except ImportError:
+    from xml.etree.ElementTree import _Element as XMLElement
 
 class RootParseTestCase(SampleParseTestCase):
     """ Test parsing of:

--- a/tests/test_parser_functional.py
+++ b/tests/test_parser_functional.py
@@ -2,7 +2,7 @@ from .base import SampleParseTestCase
 from pyraml import entities
 
 from mock import patch
-from lxml.etree import _Element as XMLElement
+from xml.etree.ElementTree import _Element as XMLElement
 
 
 class RootParseTestCase(SampleParseTestCase):
@@ -88,11 +88,10 @@ class RootParseTestCase(SampleParseTestCase):
         })
         self.assertIsInstance(data.schemas['league-xml'], XMLElement)
         self.assertListEqual(
-            data.schemas['league-xml'].keys(),
-            ['elementFormDefault', 'targetNamespace'])
-        self.assertListEqual(
-            data.schemas['league-xml'].values(),
-            ['qualified', 'http://example.com/schemas/soccer'])
+            data.schemas['league-xml'].items(), [
+                ('elementFormDefault', 'qualified'),
+                ('targetNamespace', 'http://example.com/schemas/soccer')
+            ])
 
     def test_schemas_not_provided(self):
         data = self.load('null-elements.yaml')
@@ -337,8 +336,7 @@ class ResourceParseTestCase(SampleParseTestCase):
         data = self.load('full-config.yaml')
         body = data.resources['/'].methods['post'].body
         self.assertIsInstance(body['text/xml'].schema, XMLElement)
-        self.assertEqual(body['text/xml'].schema.keys(), ['bar'])
-        self.assertEqual(body['text/xml'].schema.values(), ['baz'])
+        self.assertEqual(body['text/xml'].schema.items(), [('bar', 'baz')])
 
     def test_method_body_named_schema_parsed(self):
         data = self.load('full-config.yaml')
@@ -604,8 +602,7 @@ class SecuritySchemesParseTestCase(SampleParseTestCase):
         self.assertIsNone(appjson.formParameters)
         xmlbody = body['text/xml']
         self.assertIsInstance(xmlbody.schema, XMLElement)
-        self.assertEqual(xmlbody.schema.keys(), ['buz'])
-        self.assertEqual(xmlbody.schema.values(), ['biz'])
+        self.assertEqual(xmlbody.schema.items(), [('buz', 'biz')])
 
     def test_describedby_headers_parsed(self):
         data = self.load('full-config.yaml')


### PR DESCRIPTION
I was frustrated with the long 'pip instal' times that resulted from using lxml as a dependency and replaced it with Python's native xml implementation. I modified the tests to fit the slightly different API (the values() method is missing from the Element class).

Python's native implementation is much slower that lxml, but I'm not sure how important this is for RAML.

Love the package, btw, thanks.