### PR TITLE
Python 3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+language: python
+sudo: false
+python:
+  - "2.7"
+env:
+  global:
+    - PIP_DOWNLOAD_CACHE=$HOME/.pip_cache
+  matrix:
+    - TOX_ENV=py27
+    - TOX_ENV=py34
+cache:
+  directories:
+    - $HOME/.pip-cache/
+install:
+  - "travis_retry pip install setuptools --upgrade"
+  - "travis_retry pip install tox"
+script:
+  - tox -e $TOX_ENV
+after_script:
+  - cat .tox/$TOX_ENV/log/*.log

--- a/README.md
+++ b/README.md
@@ -31,6 +31,11 @@ To run tests use:
 
     $ python -m nose
 
+To run tests on all supported python versions:
+
+    $ pip install tox
+    $ tox
+
 
 Using pyraml-parser
 ===================
@@ -48,7 +53,7 @@ function:
 MIT LICENSE
 ---
 
-Copyright (c) 2011-2013 Jason Huck, Simon Georget
+Copyright (c) 2011-2015 Jason Huck, Simon Georget
 http://opensource.org/licenses/MIT
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:

--- a/pyraml/__init__.py
+++ b/pyraml/__init__.py
@@ -4,8 +4,8 @@ import mimetypes
 import yaml
 from collections import OrderedDict
 
-from raml_elements import ParserRamlInclude
-from constants import RAML_CONTENT_MIME_TYPES
+from .raml_elements import ParserRamlInclude
+from .constants import RAML_CONTENT_MIME_TYPES
 
 
 # Bootstrapping: making able mimetypes package to recognize RAML and YAML

--- a/pyraml/entities.py
+++ b/pyraml/entities.py
@@ -1,10 +1,10 @@
 __author__ = 'ad'
 
-from model import Model
-from fields import (
+from .model import Model
+from .fields import (
     String, Reference, Map, List, Bool, Int, Float, Or, Null,
     Choice, RamlNamedParametersMap, JSONData, XMLData)
-from constants import NAMED_PARAMETER_TYPES, RAML_VALID_PROTOCOLS
+from .constants import NAMED_PARAMETER_TYPES, RAML_VALID_PROTOCOLS
 
 
 class SecuredEntity(object):

--- a/pyraml/parser.py
+++ b/pyraml/parser.py
@@ -1,17 +1,20 @@
 __author__ = 'ad'
 
+import itertools
 import contextlib
-import urllib2
 import mimetypes
 import os.path
-import urlparse
 import yaml
 from collections import OrderedDict
 
-from raml_elements import ParserRamlInclude
-from entities import (
+from six.moves import urllib_parse as urlparse
+from six.moves import urllib as urllib2
+from six.moves import reduce
+
+from .raml_elements import ParserRamlInclude
+from .entities import (
     RamlRoot, RamlResource, RamlMethod, RamlResourceType)
-from constants import (
+from .constants import (
     RAML_SUPPORTED_FORMAT_VERSION, RAML_CONTENT_MIME_TYPES,
     HTTP_METHODS)
 
@@ -20,7 +23,7 @@ __all__ = ["RamlException", "RamlNotFoundException", "RamlParseException",
            "ParseContext", "load", "parse"]
 
 
-class RamlException(StandardError):
+class RamlException(Exception):
     pass
 
 
@@ -146,7 +149,7 @@ def parse_protocols(ctx, base_uri=None):
     protocols = ctx.get_property_with_schema(
         'protocols', RamlRoot.protocols)
     if protocols is None and base_uri is not None:
-        protocols = [urllib2.splittype(base_uri)[0]]
+        protocols = [base_uri.partition(':')[0]]
     if protocols:
         protocols = [p.upper() for p in protocols]
     return protocols
@@ -300,7 +303,7 @@ def parse_resource_types(ctx):
     if isinstance(resource_types, ParseContext):
         resource_types = resource_types.data
     resource_types = reduce(
-        lambda x, y: dict(x.items() + y.items()),
+        lambda x, y: dict(itertools.chain(x.items(), y.items())),
         resource_types)
 
     resource_types_context = ParseContext(resource_types, ctx.relative_path)

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     install_requires=[
         'setuptools',
         'PyYAML>=3.10',
-        'importhelpers>=0.2'
+        'six',
     ],
     zip_safe=True,
     include_package_data=True,
@@ -35,6 +35,10 @@ setup(
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
         'Programming Language :: Python',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.4',
         'Topic :: Software Development :: Libraries',
     ],
 )

--- a/tests/test_parser_functional.py
+++ b/tests/test_parser_functional.py
@@ -6,7 +6,7 @@ from mock import patch
 try:
     from lxml.etree import _Element as XMLElement
 except ImportError:
-    from xml.etree.ElementTree import _Element as XMLElement
+    from xml.etree.ElementTree import Element as XMLElement
 
 class RootParseTestCase(SampleParseTestCase):
     """ Test parsing of:
@@ -90,11 +90,11 @@ class RootParseTestCase(SampleParseTestCase):
             }
         })
         self.assertIsInstance(data.schemas['league-xml'], XMLElement)
-        self.assertListEqual(
-            data.schemas['league-xml'].items(), [
+        self.assertSetEqual(
+            set(data.schemas['league-xml'].items()), set([
                 ('elementFormDefault', 'qualified'),
                 ('targetNamespace', 'http://example.com/schemas/soccer')
-            ])
+            ]))
 
     def test_schemas_not_provided(self):
         data = self.load('null-elements.yaml')
@@ -113,7 +113,7 @@ class RootParseTestCase(SampleParseTestCase):
     def test_secured_by_parsed(self):
         data = self.load('full-config.yaml')
         self.assertEqual(len(data.securedBy), 3)
-        null, oauth2, oauth1 = sorted(data.securedBy)
+        oauth2, oauth1, null = data.securedBy
         self.assertIsNone(null)
         self.assertDictEqual(oauth2, {
             'oauth_2_0': {'scopes': ['foobar']}
@@ -211,7 +211,7 @@ class ResourceParseTestCase(SampleParseTestCase):
         data = self.load('full-config.yaml')
         self.assertEqual(len(data.resources), 3)
         # Order or resources is preserved
-        self.assertListEqual(data.resources.keys(), ['/', '/media', '/tags'])
+        self.assertListEqual(list(data.resources.keys()), ['/', '/media', '/tags'])
         self.assertEqual(data.resources['/'].displayName, 'Root resource')
         self.assertEqual(
             data.resources['/'].description,
@@ -425,7 +425,7 @@ class ResourceParseTestCase(SampleParseTestCase):
         data = self.load('full-config.yaml')
         secured = data.resources['/'].securedBy
         self.assertEqual(len(secured), 3)
-        null, oauth2, oauth1 = sorted(secured)
+        oauth2, oauth1, null = secured
         self.assertIsNone(null)
         self.assertDictEqual(oauth2, {
             'oauth_2_0': {'scopes': ['comments']}
@@ -436,7 +436,7 @@ class ResourceParseTestCase(SampleParseTestCase):
         data = self.load('full-config.yaml')
         secured = data.resources['/'].methods['head'].securedBy
         self.assertEqual(len(secured), 2)
-        oauth2, oauth1 = sorted(secured)
+        oauth2, oauth1 = secured
         self.assertDictEqual(oauth2, {
             'oauth_2_0': {'scopes': ['more comments']}
         })
@@ -496,7 +496,7 @@ class TraitsParseTestCase(SampleParseTestCase):
         data = self.load('full-config.yaml')
         self.assertEqual(len(data.traits), 3)
         self.assertListEqual(
-            data.traits.keys(),
+            list(data.traits.keys()),
             ['simple', 'knotty', 'orderable'])
         self.assertEqual(data.traits['simple'].usage, 'simple trait')
         self.assertIsNone(data.traits['simple'].description)

--- a/tests/test_references.py
+++ b/tests/test_references.py
@@ -1,0 +1,14 @@
+from unittest import TestCase
+
+import collections
+
+from pyraml.fields import Reference
+
+
+class ValidationTestCase(TestCase):
+    """ Test validation and invalid values processing stuff. """
+
+    def test_reference_dotted_path_import(self):
+        reference = Reference("collections.deque")
+        reference._lazy_import()
+        assert reference.ref_class is collections.deque

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,16 @@
+[tox]
+envlist=
+    py27,
+    py34,
+
+[testenv]
+commands=python -m nose
+deps =
+    nose
+    mock
+
+[testenv:py27]
+basepython=python2.7
+
+[testenv:py34]
+basepython=python3.4


### PR DESCRIPTION
## What was wrong?

No support for python 3

## How was it fixed.

- Added `six` as a dependency.
- Changed `urllib2` imports to come from `six.moves`
- Changed `urlparse` imports to come from `six.moves`
- converted usage of `basestring` to use `six.string_types`
- converted call of `isinstance(thing, (int, long))` to `isinstance(thing, six.integer_types)`
- removed usage of `importhelpers` as it's internals were not python3 compatible, and replaced with functionally equivalent code.  (This has tests added to cover it).
- Added `tox` as outer testing harness to allow testing against python 3.4 as well as python 2.7
- Added section in `README.md` about how to run tests via tox.
- added `.travis.yml` to enable testing via `travis-ci.org`
- Change relative imports to be prefixed with the appropriate `.` so that they work with python3
- Change `from xml.etree.ElementTree import _Element as XMLElement` to be `from xml.etree.ElementTree import Element as XMLElement`.  Based on my experimentation in python 2.7.9 these two objects are the same.
- Changed calls to `thing.iteritems()` to use `thing.items()` for python3 compatibility.
- Changed calls to `unicode(s)` to use `six.text_type(s)`
- Used `from six.moves import reduce` to be python3 compliant where reduce is used.
- Changed to use `itertools.chain(dict_1.items(), dict_2.items())` replacing `dict_1.items() + dict_2.items()` since the `ItemsView` objects returned in python3 cannot be added together.
- replaced call to `urllib2.splittype(s)[0]` with equivalent call to `s.partition[':'][0]` since `urllib2.splittypes` appears to be an undocumented urllib2 api that is removed in python3.
- wrapped calls to `d.keys()` in `list` so that `assertListEqual` calls will pass.
- removed `sorted()` calls in tests that don't appear to be needed and were throwing errors in python3 due to trying to sort disperate types.
- converted one test to use `assertSetEqual` call since calls to `dict.items()` don't return consistently ordered elements and I was experiencing intermittent test failures.
- Added indicators to `setup.py` as to what versions of python were supported so that `pypi` will know that this package is python3 compatable.

I also took the liberty of updating the Copyright dates in the README.  Happy to reverse this change if it's unwelcome.

## How can you see the changes

- Ideally nothing has changed in the functionality.  Test suite indicates this is the case.
- You can look and see the tests have run on both versions of python and passed on the travis-run associated with my fork.  https://travis-ci.org/pipermerriam/pyraml-parser/builds/61535351
- You can enable travis on the main repo to see the tests run on this pull request as well http://docs.travis-ci.com/user/getting-started/

Here is a cute animal picture for your troubles

![monkey-riding-a-dog](https://cloud.githubusercontent.com/assets/824194/7503933/68e161f8-f403-11e4-8e17-81259768d3aa.jpg)
