### PR TITLE
Added test validating RAML with double property `title`

### DIFF
--- a/tests/samples/invalid/invalid-double-title.yaml
+++ b/tests/samples/invalid/invalid-double-title.yaml
@@ -1,0 +1,8 @@
+#%RAML 0.8
+---
+title: Schema with double title entry in YAML
+title: Schema with double title entry in YAML
+version: v1
+baseUri: https://sample.com/api
+/media:
+    get: !!null

--- a/tests/test_validation_functional.py
+++ b/tests/test_validation_functional.py
@@ -40,3 +40,9 @@ class ValidationTestCase(SampleParseTestCase):
         self.assertEqual(
             data.schemas['invalid-xml'].strip(),
             '<?xml version="1.0" encoding="ISO-8859-1" ?>')
+
+    def test_invalid_double_title(self):
+        args = ('invalid', 'invalid-double-title.yaml')
+        expected = ("root property already used: title")
+        self.assertRaisesRegexp(
+            ValidationError, expected, self.load, *args)


### PR DESCRIPTION
Reported as issue #20

        new file:   tests/samples/invalid/invalid-double-title.yaml
        modified:   tests/test_validation_functional.py