### PR TITLE
Loads json scheme as OrderedDict

### DIFF
--- a/pyraml/fields.py
+++ b/pyraml/fields.py
@@ -554,10 +554,10 @@ class EncodedDataBase(BaseField):
 
 class JSONData(EncodedDataBase):
     """ Represents a JSON encoded data. """
-    result_type = dict
+    result_type = OrderedDict
 
     def load_data(self, value):
-        return json.loads(value)
+        return json.loads(value, object_pairs_hook=OrderedDict)
 
 
 class XMLData(EncodedDataBase):


### PR DESCRIPTION
the project I'm developing it was necessary to display the JSON scheme ordered. I just modified the result_type to OrderedDict and add object_pairs_hook into json.loads in the class JSONData