### PR TITLE
extend handling of example, type and schema

### DIFF
--- a/pyraml/__init__.py
+++ b/pyraml/__init__.py
@@ -32,6 +32,7 @@ for mtype in RAML_CONTENT_MIME_TYPES:
 
 # making able mimetypes package to recognize JSON file type
 mimetypes.add_type("application/json", ".json")
+mimetypes.add_type("application/json", ".schema")
 
 # Configure PyYaml to recognize RAML additional constructions
 yaml.add_representer(ParserRamlInclude, ParserRamlInclude.representer)

--- a/pyraml/entities.py
+++ b/pyraml/entities.py
@@ -31,9 +31,10 @@ class ResourceTypedEntity(object):
     """ Represents entities that may have resourceTypes
     specified in ``type`` field.
     """
-    type = Or(String(),
-              Map(String(),
-                  Map(String(), String())))
+    type_ = Or(String(),
+               Map(String(),
+                   Map(String(), Or(String(), Int()))),
+               field_name='type')
 
 
 class RamlDocumentation(Model):
@@ -79,7 +80,7 @@ class RamlBody(Model):
     in which the key MUST be a valid media type.
     """
     schema = Or(JSONData(), XMLData(), String())
-    example = String()
+    example = Or(JSONData(), String())
     notNull = Bool()
     formParameters = RamlNamedParametersMap()
 

--- a/pyraml/parser.py
+++ b/pyraml/parser.py
@@ -6,6 +6,7 @@ import mimetypes
 import os.path
 import codecs
 import yaml
+import json
 try:
     from collections import OrderedDict
 except ImportError:
@@ -60,6 +61,13 @@ class ParseContext(object):
         """
         if isinstance(data, ParserRamlInclude):
             file_content, file_type = self._load_resource(data.file_name)
+
+            if _is_mime_type_json(file_type):
+                file_content_dict = {}
+                file_content_dict['fileName'] = data.file_name
+                file_content_dict['content'] = file_content
+                file_content = json.dumps(file_content_dict)
+
             if _is_mime_type_raml(file_type):
                 new_relative_path = _calculate_new_relative_path(
                     self.relative_path, data.file_name)
@@ -260,7 +268,7 @@ def parse_resource(ctx, property_name, parent_object):
     resource.uriParameters = resource_ctx.get_property_with_schema(
         "uriParameters", RamlResource.uriParameters)
     resource.type = resource_ctx.get_property_with_schema(
-        "type", RamlResource.type)
+        RamlResource.type_.field_name, RamlResource.type_)
     resource.is_ = resource_ctx.get_property_with_schema(
         RamlResource.is_.field_name, RamlResource.is_)
     resource.baseUriParameters = resource_ctx.get_property_with_schema(


### PR DESCRIPTION
+ Add the name of the example and schema files aside with there content when parsing
+ Handle "type" field in raml that can be a dictionary