### PR TITLE
Add Python 3.5 & 3.6 to Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ sudo: false
 python:
   - "2.7"
   - "3.4"
+  - "3.5"
+  - "3.6"
 cache:
   pip: true
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,19 +2,12 @@ language: python
 sudo: false
 python:
   - "2.7"
-env:
-  global:
-    - PIP_DOWNLOAD_CACHE=$HOME/.pip_cache
-  matrix:
-    - TOX_ENV=py27
-    - TOX_ENV=py34
+  - "3.4"
 cache:
-  directories:
-    - $HOME/.pip-cache/
+  pip: true
 install:
-  - "travis_retry pip install setuptools --upgrade"
-  - "travis_retry pip install tox"
+  - pip install tox-travis
 script:
-  - tox -e $TOX_ENV
+  - tox
 after_script:
-  - cat .tox/$TOX_ENV/log/*.log
+  - cat .tox/*/log/*.log


### PR DESCRIPTION
Uses [tox-travis](http://pypi.python.org/pypi/tox-travis) to map Travis environments to tox Python versions, and uses built-in Travis CI pip caching.