### PR TITLE
Fix for issue with corrupted UTF-8 chars

### DIFF
--- a/pyraml/parser.py
+++ b/pyraml/parser.py
@@ -365,7 +365,7 @@ def parse_method_responses(ctx):
             responseKey = responseKeyItem
             if isinstance(responseKeyItem, str):
 
-                # Extract optional flag
+                # Extract optional flag
                 responseKeySplit = responseKeyItem.split("?")
                 responseKey = responseKeySplit[0]
 


### PR DESCRIPTION
At line 368 in '# Extract optional flag' there were 2 UTF-8 bytes that sure appear like they were a corruption of the file, see attached image ![corrupted-chars-in-pyraml](https://user-images.githubusercontent.com/533444/29419787-49a3f416-832d-11e7-9a6e-a2c71498c558.jpg)
.  They occur after the comment start, so it seems clear they were a mistake. 