### PR TITLE
Workaround to preserve original PyYAML module behavior

### DIFF
--- a/pyraml/__init__.py
+++ b/pyraml/__init__.py
@@ -1,7 +1,7 @@
 __author__ = 'ad'
 
 import mimetypes
-import yaml
+import imp
 try:
     from collections import OrderedDict
 except ImportError:
@@ -10,6 +10,10 @@ except ImportError:
 
 from .raml_elements import ParserRamlInclude
 from .constants import RAML_CONTENT_MIME_TYPES
+
+
+yaml = imp.load_module('pyraml_yaml', *imp.find_module('yaml'))
+
 
 class ValidationError(Exception):
     def __init__(self, validation_errors):

--- a/pyraml/parser.py
+++ b/pyraml/parser.py
@@ -5,7 +5,7 @@ import contextlib
 import mimetypes
 import os.path
 import codecs
-import yaml
+import imp
 import json
 try:
     from collections import OrderedDict
@@ -28,6 +28,7 @@ from .constants import (
 
 __all__ = ["RamlException", "RamlNotFoundException", "RamlParseException",
            "ParseContext", "load", "parse"]
+yaml = imp.load_module('pyraml_yaml', *imp.find_module('yaml'))
 
 
 class RamlException(Exception):

--- a/pyraml/raml_elements.py
+++ b/pyraml/raml_elements.py
@@ -1,6 +1,9 @@
 __author__ = 'ad'
 
-import yaml
+import imp
+
+
+yaml = imp.load_module('pyraml_yaml', *imp.find_module('yaml'))
 
 
 class ParserRamlInclude(yaml.YAMLObject):


### PR DESCRIPTION
### Background
Workaround for issue #34.

### Changes
* Specify `pyraml_yaml` as module name for PyYAML module by using `imp` module

### Notes
* `imp.load_module` is deprecated, but equivalent implementation without deprecated functions will lose backward compatibility and will be difficult to fall back to deprecated implementation.
    * The equivalent implementation is like below.
        * In `pyraml/__init__.py`
            ```
            import importlib.util

            pyyaml_mod_spec = importlib.util.find_spec('yaml')
            pyyaml_module = importlib.util.module_from_spec(pyyaml_mod_spec)
            pyyaml_mod_spec.loader.exec_module(pyyaml_module)
            sys.modules['pyraml_yaml'] = pyyaml_module 
            yaml = pyyaml_module

            # yaml.add_representer(...)
            ```
        * In the other python scripts in `pyraml` directory
            ```
            import pyraml_yaml as yaml

            # yaml.load(...)
            ```



