### PR TITLE
Pin PyYAML==3.13 and fix unit tests

### DIFF
--- a/pyraml/parser.py
+++ b/pyraml/parser.py
@@ -62,13 +62,6 @@ class ParseContext(object):
         if isinstance(data, ParserRamlInclude):
             file_content, file_type = self._load_resource(data.file_name)
 
-            if not _is_mime_type_raml(file_type):
-
-                file_content_dict = {}
-                file_content_dict['fileName'] = data.file_name
-                file_content_dict['content'] = file_content
-                file_content = json.dumps(file_content_dict)
-
             if _is_mime_type_raml(file_type):
                 new_relative_path = _calculate_new_relative_path(
                     self.relative_path, data.file_name)

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     long_description=README + '\n\n' + CHANGES,
     install_requires=[
         'setuptools',
-        'PyYAML>=3.10',
+        'PyYAML==3.13',
         'six>=1.9.0',
     ],
     tests_require=[

--- a/tests/test_parser_functional.py
+++ b/tests/test_parser_functional.py
@@ -208,7 +208,7 @@ class InclusionTestCase(SampleParseTestCase):
         data = self.load('include-body-example-json.yaml')
         responses = data.resources['/me'].methods['get'].responses[200]
         json_response = responses.body['application/json']
-        self.assertEqual(json_response.example, '{"foo": "bar"}')
+        self.assertEqual(json_response.example, {u'foo': u'bar'})
 
 
 class ResourceParseTestCase(SampleParseTestCase):

--- a/tests/test_parser_functional.py
+++ b/tests/test_parser_functional.py
@@ -8,6 +8,13 @@ try:
 except ImportError:
     from xml.etree.ElementTree import Element as XMLElement
 
+try:
+    from collections import OrderedDict
+except ImportError:
+    # For python 2.6 additional package ordereddict should be installed
+    from ordereddict import OrderedDict
+
+
 class RootParseTestCase(SampleParseTestCase):
     """ Test parsing of:
 
@@ -332,7 +339,7 @@ class ResourceParseTestCase(SampleParseTestCase):
             "required": False,
             "type": "object"
         })
-        self.assertEqual(appjson.example, '{ "input": "hola" }')
+        self.assertEqual(appjson.example, OrderedDict([(u'input', u'hola')]))
         self.assertIsNone(appjson.formParameters)
 
     def test_method_body_xml_parsed(self):
@@ -387,7 +394,7 @@ class ResourceParseTestCase(SampleParseTestCase):
         self.assertEqual(len(responses[200].body), 1)
         self.assertEqual(
             responses[200].body['application/json'].example,
-            '{ "key": "value" }')
+            OrderedDict([(u'key', u'value')]))
         self.assertEqual(
             responses[200].body['application/json'].schema,
             'league-json')
@@ -482,7 +489,7 @@ class ResourceTypesParseTestCase(SampleParseTestCase):
         self.assertEqual(len(post.responses), 1)
         resp200 = post.responses[200]
         self.assertEqual(resp200.body['application/json'].example,
-                         '{ "message": "Foo" }')
+                         OrderedDict([(u'message', u'Foo')]))
 
 
 class TraitsParseTestCase(SampleParseTestCase):
@@ -536,7 +543,7 @@ class TraitsParseTestCase(SampleParseTestCase):
         resp200 = data.traits['orderable'].responses[200]
         self.assertEqual(len(resp200.body), 1)
         self.assertEqual(resp200.body['application/json'].example,
-                         '{ "message": "Bar" }')
+                         OrderedDict([(u'message', u'Bar')]))
 
 
 class SecuritySchemesParseTestCase(SampleParseTestCase):
@@ -601,7 +608,7 @@ class SecuritySchemesParseTestCase(SampleParseTestCase):
         self.assertEqual(len(body), 2)
         appjson = body['application/json']
         self.assertDictEqual(appjson.schema, {"foo": "bar"})
-        self.assertEqual(appjson.example, '{ "input": "hola" }')
+        self.assertEqual(appjson.example, OrderedDict([(u'input', u'hola')]))
         self.assertIsNone(appjson.formParameters)
         xmlbody = body['text/xml']
         self.assertIsInstance(xmlbody.schema, XMLElement)
@@ -627,7 +634,7 @@ class SecuritySchemesParseTestCase(SampleParseTestCase):
         self.assertEqual(resp401.description, 'Bad or expired token')
         self.assertEqual(len(resp401.body), 1)
         self.assertEqual(resp401.body['application/json'].example,
-                         '{ "message": "fail" }')
+                         OrderedDict([(u'message', u'fail')]))
         self.assertIsNone(resp401.body['application/json'].schema)
 
     def test_describedby_not_provided(self):


### PR DESCRIPTION
There was a new version of PyYAML 5.1 released in March: https://lists.gt.net/python/python/1413898.

This package requires `PyYAML>=3.10`, so any new installations will pull the new version. But, the new version has a backwards incompatible change to the `yaml.load()` function. See https://msg.pyyaml.org/load.

The change breaks the `!include` tag parsing for this package. The functionality in PyYAML is still evolving and will change for the better in 5.2 (see https://github.com/yaml/pyyaml/pull/279). Thus I would rather wait with >=5.1 compatibility fixes until 5.2.

In this branch, I pinned PyYAML to last working 3.13 working version. Additionally, I fixed the [unit tests] that were failing.

[unit tests]: https://travis-ci.org/mzagozen/pyraml-parser/builds/524974270

@an2deg please activate the project in Travis: https://travis-ci.org/an2deg/pyraml-parser. Only the repo admin can do that.