### PR TITLE
Use PyYAML >= 5.1

### DIFF
--- a/pyraml/__init__.py
+++ b/pyraml/__init__.py
@@ -2,14 +2,10 @@ __author__ = 'ad'
 
 import mimetypes
 import yaml
-try:
-    from collections import OrderedDict
-except ImportError:
-    # For python 2.6 additional package ordereddict should be installed
-    from ordereddict import OrderedDict
 
-from .raml_elements import ParserRamlInclude
+
 from .constants import RAML_CONTENT_MIME_TYPES
+
 
 class ValidationError(Exception):
     def __init__(self, validation_errors):
@@ -18,11 +14,6 @@ class ValidationError(Exception):
     def __str__(self):
         return repr(self.errors)
 
-class UniqOrderedDict(OrderedDict):
-    def __setitem__(self, key, value):
-        if key in self:
-            raise ValidationError("Property already used: {0}".format(key))
-        super(UniqOrderedDict, self).__setitem__(key, value)
 
 # Bootstrapping: making able mimetypes package to recognize RAML and YAML
 # file types
@@ -33,22 +24,3 @@ for mtype in RAML_CONTENT_MIME_TYPES:
 # making able mimetypes package to recognize JSON file type
 mimetypes.add_type("application/json", ".json")
 mimetypes.add_type("application/json", ".schema")
-
-# Configure PyYaml to recognize RAML additional constructions
-yaml.add_representer(ParserRamlInclude, ParserRamlInclude.representer)
-yaml.add_constructor(ParserRamlInclude.yaml_tag, ParserRamlInclude.loader)
-
-
-# Configure representer/constructor to save the order of elements
-# in a RAML/YAML structure
-def dict_representer(dumper, data):
-    return dumper.represent_dict(data.iteritems())
-
-
-def dict_constructor(loader, node):
-    return UniqOrderedDict(loader.construct_pairs(node))
-
-
-yaml.add_representer(OrderedDict, dict_representer)
-yaml.add_constructor(yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
-                     dict_constructor)

--- a/pyraml/parser.py
+++ b/pyraml/parser.py
@@ -66,7 +66,7 @@ class ParseContext(object):
                 new_relative_path = _calculate_new_relative_path(
                     self.relative_path, data.file_name)
                 _included_ctx = ParseContext(
-                    yaml.load(file_content),
+                    yaml.safe_load(file_content),
                     new_relative_path)
                 return _included_ctx._handle_load(_included_ctx.data)
             return file_content
@@ -175,7 +175,7 @@ def parse(c, relative_path):
     first_line, c = c.split('\n', 1)
     raml_version = _validate_raml_header(first_line)
 
-    context = ParseContext(yaml.load(c), relative_path)
+    context = ParseContext(yaml.safe_load(c), relative_path)
     context.preload_included_resources()
 
     root = RamlRoot(raml_version=raml_version)

--- a/pyraml/raml_elements.py
+++ b/pyraml/raml_elements.py
@@ -1,22 +1,71 @@
 __author__ = 'ad'
 
 import yaml
+from . import ValidationError
+
+try:
+    from collections import OrderedDict
+except ImportError:
+    # For python 2.6 additional package ordereddict should be installed
+    from ordereddict import OrderedDict
 
 
 class ParserRamlInclude(yaml.YAMLObject):
+    """Teach PyYAML about the `!include` tag
+
+    Usage in .yaml:
+        test: !include foo.yml
+    Will expand to:
+        test:
+          foo: bar
+    If the contents of the foo.yml file are:
+        foo: bar
+
+    This class will be found by PyYAML with inspection magic, because it
+    extends the yaml.YAMLObject class.
+    """
+
     yaml_tag = u'!include'
+    # we're using SafeLoader, this class needs to be explicitly allowed
+    yaml_loader = yaml.SafeLoader
 
     def __init__(self, file_name):
         self.file_name = file_name
 
-    @staticmethod
-    def loader(loader, node):
+    @classmethod
+    def from_yaml(cls, loader, node):
         value = loader.construct_scalar(node)
-        return ParserRamlInclude(value)
+        return cls(value)
 
-    @staticmethod
-    def representer(dumper, data):
-        return dumper.represent_scalar(ParserRamlInclude.yaml_tag, u' ' + data)
+    @classmethod
+    def to_yaml(cls, dumper, data):
+        return dumper.represent_scalar(cls.yaml_tag, u' ' + data.file_name)
 
     def __repr__(self):
         return "{}({})".format(self.__class__.__name__, self.file_name)
+
+
+class UniqueOrderedDict(OrderedDict):
+    def __setitem__(self, key, value):
+        if key in self:
+            raise ValidationError("Property already used: {0}".format(key))
+        super(UniqueOrderedDict, self).__setitem__(key, value)
+
+class ParserRamlDict(yaml.YAMLObject, UniqueOrderedDict):
+    """Teach PyYAML to preserve dict (map) key order
+
+    Uses OrderedDict with unique key values to preserve order.
+    """
+
+    yaml_tag = yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG
+    # we're using SafeLoader, this class needs to be explicitly allowed
+    yaml_loader = yaml.SafeLoader
+
+    @classmethod
+    def from_yaml(cls, loader, node):
+        value = loader.construct_pairs(node)
+        return UniqueOrderedDict(value)
+
+    @classmethod
+    def to_yaml(cls, dumper, data):
+        return dumper.represent_dict(data.iteritems())

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     long_description=README + '\n\n' + CHANGES,
     install_requires=[
         'setuptools',
-        'PyYAML==3.13',
+        'PyYAML>=5.1',
         'six>=1.9.0',
     ],
     tests_require=[


### PR DESCRIPTION
People are getting CVE hits on using an old PyYAML version. While it is possible to change usage of pyyaml to use `yaml.safe_load` even with the old version, that won't make the warning go away. It's best to just upgrade to latest. I had this branch with PyYAML 5.x compatibility fixes ready to go, but was waiting on PyYAML 5.2 to be released. It has been 6 months now. I don't think it's happening any time soon.

Anyway, the current 5.1 version has a bug where you must explicitly register the loader for every custom directive parsing class. This was supposed to be a global setting - like you specifiy you only want to use `SafeLoader`, but it doesn't work. Even with the explicit workaround, IMHO this is an improvement on the old version as it includes more documentation :)

@an2deg I set your `rel-0.1.8` branch as the base here, as that is the current public release.

Closes #39 